### PR TITLE
WYSIWYG field - Recursion prevention for 'the_content' filter

### DIFF
--- a/core/fields/wysiwyg.php
+++ b/core/fields/wysiwyg.php
@@ -2,6 +2,8 @@
 
 class cfs_Wysiwyg extends cfs_Field
 {
+    
+    static $in_filter = false;
 
     function __construct($parent)
     {
@@ -68,6 +70,14 @@ class cfs_Wysiwyg extends cfs_Field
 
     function format_value_for_api($value, $field)
     {
-        return apply_filters('the_content', $value[0]);
+        $output = $value[ 0 ];
+        
+        if ( !self::$in_filter ) {
+            self::$in_filter = true;
+            $output = apply_filters( 'the_content', $output );
+            self::$in_filter = false;
+        }
+        
+        return $output;
     }
 }


### PR DESCRIPTION
Check if field is already being filtered, prevents recursion loops if this field is called within 'the_content' filter.
