### PR TITLE
add hook for matching groups in post editor

### DIFF
--- a/cfs.php
+++ b/cfs.php
@@ -200,6 +200,10 @@ class Cfs
             }
         }
 
+        if(false !== ($filtered = apply_filters('cfs_match_groups', array($matches, $post_id, $post_type)))){
+            $matches = $filtered;
+        }
+
         return $matches;
     }
 


### PR DESCRIPTION
This is a request to add a hook so that matching groups can be further refined, if necessary. Our use case is that we'd like to apply a particular field group to a page (post_type page), but only if it's parent is a chosen page ID (and not applied to the parent itself). Figured the easiest way to do this and other such refined matching would be a hook. 
