### PR TITLE
Custom Field Types: Check if class exists before including file

### DIFF
--- a/cfs.php
+++ b/cfs.php
@@ -160,7 +160,7 @@ class Cfs
         {
             $class_name = 'cfs_' . ucwords($type);
             
-            if (!empty($path) && !class_exists($class_name))
+            if (!class_exists($class_name))
                 include_once($path);
                 
             $field_types[$type] = new $class_name($this);


### PR DESCRIPTION
Multiple classes could be included in one file, or the class could already have been included at some other point.
