### PR TITLE
notice messages

### DIFF
--- a/core/actions/save_fields.php
+++ b/core/actions/save_fields.php
@@ -34,8 +34,11 @@ if (isset($_POST['cfs']['fields']))
             'post_id' => $post_id,
             'parent_id' => $field['parent_id'],
             'weight' => $weight,
-            'options' => serialize($field['options']),
         );
+
+        if (isset($field['options']) && is_array($field['options'])) {
+            $data['options'] = serialize($field['options']);
+        }
 
         // use an existing ID if available
         if (0 < (int) $field['id'])

--- a/core/admin/meta_box_fields.php
+++ b/core/admin/meta_box_fields.php
@@ -11,6 +11,7 @@ $results = $this->api->get_input_fields($post->ID);
     Create <ul> based on field structure
 ---------------------------------------------------------------------------------------------*/
 
+$level = 0;
 $levels = array();
 $last_level = $diff = 0;
 


### PR DESCRIPTION
Hi and thanks for the nice plugin,

I've fixed two files for removing notice messages. The one in save_fields.php caused 'header already sent' because of the notice message. The other one however didn't caused that serious error, but when I first entered Add New Field Group page there was a notice in the Fields box.
