### PR TITLE
Notice cleanup

### DIFF
--- a/core/classes/api.php
+++ b/core/classes/api.php
@@ -44,7 +44,12 @@ class cfs_Api
         if (!isset($this->cache[$post_id][$options->format][$field_name]))
         {
             $fields = $this->get_fields($post_id);
-            return $fields[$field_name];
+
+            $field = null;
+            if( isset( $fields[$field_name] ) )
+                $field = $fields[$field_name];
+
+            return $field;
         }
 
         return $this->cache[$post_id][$options->format][$field_name];


### PR DESCRIPTION
Cleaned up a notice that was fired if you attempted to get() a field that was not defined. Triggered when running get() on a post that was not saved after adding your Field Group to it.
