### PR TITLE
Checkerboard pattern behind image thumbnails

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -127,7 +127,7 @@
 
 .cfs_file .file_url img {
     padding: 5px;
-    background: #fff;
+    background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAIUlEQVQYV2NkYGCQBGJ08BxdgHGIKMTiF0wPgjwz2BUCADTeBYguWvyCAAAAAElFTkSuQmCC);
     vertical-align: bottom;
     box-shadow: 0 1px 2px #ddd;
 }


### PR DESCRIPTION
I use a lot of white-on-transparent images in a project, this CSS helps the image to show up
