### PR TITLE
Add hook to filter input fields

### DIFF
--- a/includes/classes/api.php
+++ b/includes/classes/api.php
@@ -387,7 +387,7 @@ class cfs_api
             $fields[$field->id] = $field;
         }
 
-        return $fields;
+        return apply_filters('cfs_get_input_fields', $fields, $params);
     }
 
 


### PR DESCRIPTION
This adds a hook to filter which fields are displayed in a loop field.

I wanted to selectively show and hide loop sub-fields in the post edit screen based on post type and there didn't seem to be a way to do it programmatically. A filter on `get_input_fields()` seems the simplest option, but there may be a more efficient approach.

PS. Thanks for a great plugin.
