### PR TITLE
Add animated scroll to validation errors

### DIFF
--- a/assets/js/validation.js
+++ b/assets/js/validation.js
@@ -117,6 +117,9 @@ jQuery(function($) {
                             }
                             $this.find('.error').html(error_msg);
                             $this.find('.error').show();
+                            $('html, body').animate({
+                                scrollTop: $this.find('.error').offset().top
+                            }, 500);
                         }
                     }
                 }


### PR DESCRIPTION
I find it confusing to click the Publish/Update button and not see a result. This happens when validation errors occur - the validation fails and error messages are outputted, but no visual cues are given to the user if the error messages are below the fold.
This will scroll to the topmost error message on Publish/Update.
