### PR TITLE
Also apply filter when prepping SQL to pull posts from chosen post types

### DIFF
--- a/includes/fields/relationship.php
+++ b/includes/fields/relationship.php
@@ -25,6 +25,7 @@ class cfs_relationship extends cfs_field
             foreach ( $field->options['post_types'] as $type ) {
                 $where[] = $type;
             }
+            $where = apply_filters( 'cfs_field_relationship_post_types', $where );
             $where = " AND post_type IN ('" . implode( "','", $where ) . "')";
         }
 


### PR DESCRIPTION
I was able to use cfs_field_relationship_post_types to get my private post type in the options screen, but it wasn't pulling posts from that private post type when editing posts.
