### PR TITLE
Make a field's order icon white when opened

### DIFF
--- a/assets/css/fields.css
+++ b/assets/css/fields.css
@@ -318,3 +318,7 @@ body.mp6 .field_meta td.field_order:after {
 	-webkit-font-smoothing: antialiased;
 	-mos-osx-font-smoothing: grayscale;
 }
+
+body.mp6 .form_open .field_meta td.field_order:after {
+	color:#fff;
+}


### PR DESCRIPTION
This makes the field_order dashicon white instead of gray when a field is opened up:

![edit_field_group__van_patten_media__wordpress](https://cloud.githubusercontent.com/assets/1231306/3173428/09f8e042-ebe6-11e3-9874-b902b07932f8.png)

It's just slightly more pretty this way :smile: 
