### PR TITLE
Fix bug: unexpected duplicate postmeta data

### DIFF
--- a/includes/third_party.php
+++ b/includes/third_party.php
@@ -15,8 +15,8 @@ class cfs_third_party
         add_action( 'icl_make_duplicate', array( $this, 'wpml_handler' ), 10, 4 );
 
         // Duplicate Post - http://wordpress.org/plugins/duplicate-post/
-        add_action( 'dp_duplicate_post', array( $this, 'duplicate_post' ), 10, 2 );
-        add_action( 'dp_duplicate_page', array( $this, 'duplicate_post' ), 10, 2 );
+        add_action( 'dp_duplicate_post', array( $this, 'duplicate_post' ), 20, 2 );
+        add_action( 'dp_duplicate_page', array( $this, 'duplicate_post' ), 20, 2 );
     }
 
 
@@ -159,6 +159,13 @@ class cfs_third_party
         global $cfs;
 
         $field_data = $cfs->get( false, $post->ID, array( 'format' => 'raw' ) );
+        
+        if (is_array($field_data)) {
+            foreach($field_data as $key => $value) {
+                delete_post_meta($new_post_id, $key, $value);
+            }
+        }
+        
         $post_data = array( 'ID' => $new_post_id );
         $cfs->save( $field_data, $post_data );
     }


### PR DESCRIPTION
Duplicate Post plugin copies metadata, but afterwards, CFS creates new cfs field data. so result is...

original post:
![original_post_meta](https://cloud.githubusercontent.com/assets/514294/3560718/cc9f6514-0985-11e4-8679-bf1092f54ba6.png)

post copied with Duplicate Post plugin:
![cfs2](https://cloud.githubusercontent.com/assets/514294/3560720/d74be618-0985-11e4-9260-048468bd9e99.png)

![cfs3](https://cloud.githubusercontent.com/assets/514294/3560722/fb00f314-0985-11e4-80d6-17f2799cd133.png)
