### PR TITLE
Use "move" cursor on loop field hamburger icon

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -433,6 +433,7 @@ body.mp6 .cfs_loop .cfs_loop_head:before {
 	top:0;
 	color:#adadad;
 	content: '\f333';
+	cursor: move;
 }
 
 body.mp6 .cfs_loop .cfs_loop_body.open {


### PR DESCRIPTION
This PR sets the mouse cursor when the mouse is positioned over the hamburger icon in a loop field row to the "move" cursor. Previously it was the default "pointer" cursor which is set on `.cfs_loop .cfs_loop_head`.

I would include a screenshot, but I can't figure out a way to get a cursor in a screenshot. So... trust me, I guess?
