### PR TITLE
Fix for WYSIWYG settings handling if all editors on page are in 'text' tab causing tinyMCE.settings will not be defined

### DIFF
--- a/includes/fields/wysiwyg.php
+++ b/includes/fields/wysiwyg.php
@@ -119,9 +119,25 @@ class cfs_wysiwyg extends cfs_field
                     // set the wysiwyg css id
                     $(this).find('.wysiwyg').attr('id', input_id);
                     $(this).find('a.add_media').attr('data-editor', input_id);
-
+                    
+                    // if all editors on page are in 'text' tab, tinyMCE.settings will not be set
+                    if ( 'undefined' == typeof tinyMCE.settings ) {,
+                        // let's pull from tinyMCEPreInit for main content area (if it's set)
+                        if ( 'undefined' != typeof tinyMCEPreInit && 'undefined' != typeof tinyMCEPreInit.mceInit.content ) {
+                            tinyMCE.settings = tinyMCEPreInit.mceInit.content;
+                        }
+                        // otherwise, setup basic settings object
+                        else {
+                            tinymce.settings = {
+                                wpautop : true,
+                                resize : 'vertical',
+                                toolbar2 : 'code'
+                            };  
+                        }
+                    }
+                    
                     // add the "code" button
-                    if (tinyMCE.settings.toolbar2.indexOf('code') < 0) {
+                    if ( tinyMCE.settings.toolbar2.indexOf('code') < 0) {
                         tinyMCE.settings.toolbar2 += ',code';
                     }
 


### PR DESCRIPTION
If all editors on page are in 'text' tab, tinyMCE.settings will not be set, so this PR fixes a JS error resulting from tinyMCE.settings not being defined, and set initial settings to tinyMCEPreInit for main content area.

Otherwise, just set a couple of defaults in the object.
