### PR TITLE
Add fallback parameter in dynamic loop label token

### DIFF
--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -94,7 +94,7 @@ class cfs_loop extends cfs_field
     {
         $loop_field_ids = array();
         $loop_field = CFS()->api->get_input_fields(array('field_id' => $field_id));
-        $row_label = $this->get_option($loop_field[$field_id], 'row_label', __('Loop Row', 'cfs'));
+        $row_label = $this->dynamic_label($this->get_option($loop_field[$field_id], 'row_label', __('Loop Row', 'cfs')));
 
         // Get the sub-fields
         $results = CFS()->api->get_input_fields(array('group_id' => $group_id, 'parent_id' => $field_id));
@@ -160,7 +160,7 @@ class cfs_loop extends cfs_field
         dynamic_label
     ---------------------------------------------------------------------------------------------*/
 
-    function dynamic_label($row_label, $fields, $values)
+    function dynamic_label($row_label, $fields = array(), $values = array())
     {
         preg_match_all("/({(.*?)})/", $row_label, $matches);
         if (!empty($matches))
@@ -172,12 +172,20 @@ class cfs_loop extends cfs_field
                 $all_fields[$field->name] = (int) $field->id;
             }
 
-            foreach ($matches[2] as $field_name)
+            foreach ($matches[2] as $token)
             {
+                //check for fallback
+                $tmp = explode(':', $token);
+                $field_name = $tmp[0];
+                $fallback = isset($tmp[1]) ? $tmp[1] : false;
                 $field_id = isset($all_fields[$field_name]) ? $all_fields[$field_name] : false;
                 if (isset($values[$field_id]))
                 {
-                    $row_label = str_replace('{' . $field_name . '}', $values[$field_id], $row_label);
+                    $row_label = str_replace('{' . $token . '}', $values[$field_id], $row_label);
+                }
+                elseif (false !== $fallback)
+                {
+                     $row_label = str_replace('{' . $token . '}', $fallback, $row_label);
                 }
             }
         }


### PR DESCRIPTION
With dynamic field labels, when adding new loop items, the label shows the actual token as the label, eg {name}. With this modification the token takes the form of {field_name:fallback}, where the fallback will become the label for cloned fields and also for cases when a value is not set, eg {name:Enter Name}. This is backwards compatible with using just the field name in the token.
