### PR TITLE
Better loop field toggle icon

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -393,6 +393,10 @@ body.mp6 .cfs_input .cfs_toggle_field:before {
 	content: '\f140';
 }
 
+body.mp6 .cfs_input .open .cfs_toggle_field:before {
+	content: '\f142';
+}
+
 body.mp6 .cfs_input .cfs_delete_field:before,
 body.mp6 .cfs_relationship .selected_posts div span.remove:before,
 body.mp6 .cfs_user .selected_posts div span.remove:before {

--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -102,7 +102,7 @@ class cfs_loop extends cfs_field
         ob_start();
     ?>
         <div class="loop_wrapper">
-            <div class="cfs_loop_head">
+            <div class="cfs_loop_head open">
                 <a class="cfs_delete_field"></a>
                 <a class="cfs_toggle_field"></a>
                 <span class="label"><?php echo esc_attr($row_label); ?></span>
@@ -213,7 +213,7 @@ class cfs_loop extends cfs_field
                 $row_offset = max($i, $row_offset);
     ?>
         <div class="loop_wrapper">
-            <div class="cfs_loop_head">
+            <div class="cfs_loop_head<?php echo $css_class; ?>">
                 <a class="cfs_delete_field"></a>
                 <a class="cfs_toggle_field"></a>
                 <span class="label"><?php echo esc_attr($this->dynamic_label($row_label, $results, $values[$i])); ?>&nbsp;</span>
@@ -291,12 +291,14 @@ class cfs_loop extends cfs_field
                 });
 
                 $(document).on('click', '.cfs_loop_head', function() {
+                    $(this).toggleClass('open');
                     $(this).siblings('.cfs_loop_body').toggleClass('open');
                 });
 
                 // Hide or show all rows
                 // The HTML is located in includes/form.php
                 $(document).on('click', '.cfs_loop_toggle', function() {
+                    $(this).closest('.field').find('.cfs_loop_head').toggleClass('open');
                     $(this).closest('.field').find('.cfs_loop_body').toggleClass('open');
                 });
 


### PR DESCRIPTION
This PR updates the loop field code and design to change an individual loop field's toggle icon based on whether it's open or closed.

Open:

![cursor_and_new_campaign_ __225__ _wordpress](https://cloud.githubusercontent.com/assets/1231306/4519874/97eb897e-4cce-11e4-8132-322a290c4f4d.png)

Closed:

![cursor_and_new_campaign_ __225__ _wordpress](https://cloud.githubusercontent.com/assets/1231306/4519875/a07c203a-4cce-11e4-907c-dbaa62933ee6.png)

The up/down arrows mirror the WP meta box toggle icons.

This PR does not cover legacy styles, for non mp6-ers. It could also probably be simplified by applying the "open" class to the whole loop div, and tweaking the styles to match. I'm happy to refactor if that's desired.
