### PR TITLE
Fix for field alternating row style in the move cell

### DIFF
--- a/assets/css/fields.css
+++ b/assets/css/fields.css
@@ -296,7 +296,7 @@ span.checkbox.active {
 ---------------------------------------------------------------------------------------------*/
 
 body.mp6 .field_meta td.field_order {
-	background:#fcfcfc;
+	background:#fff;
 	position:relative;
 }
 


### PR DESCRIPTION
This fixes the alternating row style; the move cell had a specific background colour, so it didn't look quite right.

Before:
![screen shot 2014-10-20 at 11 37 16](https://cloud.githubusercontent.com/assets/1231306/4704058/7a0569d2-586f-11e4-9fc7-e9878f43a2ba.png)

After:
![screen shot 2014-10-20 at 11 37 04](https://cloud.githubusercontent.com/assets/1231306/4704061/7dbe16d2-586f-11e4-9b5b-5f52c2ab729a.png)
