### PR TITLE
use CFS_VERSION to bust through caches

### DIFF
--- a/includes/form.php
+++ b/includes/form.php
@@ -138,10 +138,10 @@ class cfs_form
 
         wp_enqueue_script( 'jquery-ui-core');
         wp_enqueue_script( 'jquery-ui-sortable');
-        wp_enqueue_script( 'cfs-validation', CFS_URL . '/assets/js/validation.js', array( 'jquery' ) );
-        wp_enqueue_script( 'jquery-powertip', CFS_URL . '/assets/js/jquery-powertip/jquery.powertip.min.js', array( 'jquery' ) );
-        wp_enqueue_style( 'jquery-powertip', CFS_URL . '/assets/js/jquery-powertip/jquery.powertip.css' );
-        wp_enqueue_style( 'cfs-input', CFS_URL . '/assets/css/input.css' );
+        wp_enqueue_script( 'cfs-validation', CFS_URL . '/assets/js/validation.js', array( 'jquery' ), CFS_VERSION );
+        wp_enqueue_script( 'jquery-powertip', CFS_URL . '/assets/js/jquery-powertip/jquery.powertip.min.js', array( 'jquery' ), CFS_VERSION );
+        wp_enqueue_style( 'jquery-powertip', CFS_URL . '/assets/js/jquery-powertip/jquery.powertip.css', array(), CFS_VERSION );
+        wp_enqueue_style( 'cfs-input', CFS_URL . '/assets/css/input.css', array(), CFS_VERSION );
     }
 
 


### PR DESCRIPTION
This PR adds the CFS_VERSION constant as the cache busting version string for a few `wp_enqeueue_*` references. This will allow users to always receive the correct version of a script/style after a plugin update.