### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "mgibbs189/custom-field-suite",
+  "description": "Lightweight Custom Fields Plugin for WordPress",
+  "keywords": ["wordpress", "plugin"],
+  "homepage": "http://customfieldsuite.com/",
+  "license": "GPL-2.0",
+  "authors": [
+    {
+      "name": "Matt Gibbs",
+      "homepage": "https://twitter.com/mgibbs189"
+    }
+  ],
+  "type": "wordpress-plugin",
+  "support": {
+    "issues": "https://github.com/mgibbs189/custom-field-suite/issues",
+    "wiki": "https://github.com/mgibbs189/custom-field-suite/wiki",
+    "source": "https://github.com/mgibbs189/custom-field-suite"
+  },
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}


### PR DESCRIPTION
This PR adds a composer.json file. This allows users to add a custom repository to their project's composer.json file and require specific tagged versions of CFS (or trunk/master), like so:

```json
...
  "repositories": [
    {
      "type": "vcs",
      "url" : "https://github.com/mgibbs189/custom-field-suite"
    }
  ],
  "require": {
    "mgibbs189/custom-field-suite": "~2.3"
  },
...
```

I used two-space-tab JSON, rather than a tab character. This is normal for JSON, but a bit unusual for WordPress (many plugins with composer.json files use the tab character in JSON). If you'd like to use a tab character, I'm happy to update the PR.