### PR TITLE
 Fix a select field in admin panel

### DIFF
--- a/includes/fields/select.php
+++ b/includes/fields/select.php
@@ -44,7 +44,6 @@ class cfs_select extends cfs_field
     ?>
         <select name="<?php echo $field->input_name; ?>" class="<?php echo $field->input_class; ?>"<?php echo $multiple; ?>>
         <?php foreach ($field->options['choices'] as $val => $label) : ?>
-            <?php $val = ('{empty}' == $val) ? '' : $val; ?>
             <?php $selected = in_array($val, (array) $field->value) ? ' selected' : ''; ?>
             <option value="<?php echo esc_attr($val); ?>"<?php echo $selected; ?>><?php echo esc_attr($label); ?></option>
         <?php endforeach; ?>
@@ -156,10 +155,11 @@ class cfs_select extends cfs_field
         $choices = $field->options['choices'];
 
         // Return an associative array (value, label)
-        foreach ($value as $val)
-        {
-            $value_array[$val] = isset($choices[$val]) ? $choices[$val] : $val;
-        }
+				if(is_array($value))
+	        foreach ($value as $val)
+	        {
+	            $value_array[$val] = isset($choices[$val]) ? $choices[$val] : $val;
+	        }
 
         return $value_array;
     }


### PR DESCRIPTION
1.  Fix a select field in admin panel, where select field can equal a zero value, for example:
	0 : First value
	1 : Second value
2. Sometimes then calling CFS()->get() on select field in format value function, appear error if $value not array, fixed it.