### PR TITLE
Support dynamic fields for Select fields

### DIFF
--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -351,7 +351,14 @@ class cfs_loop extends cfs_field
                 $field_id = isset( $all_fields[ $field_name ] ) ? $all_fields[ $field_name ] : false;
 
                 if ( isset( $values[ $field_id ] ) ) {
-                    $row_label = str_replace( '{' . $token . '}', $values[ $field_id ], $row_label );
+                    if ($field->type == 'select') {
+                        $row_select_key = reset($values[ $field_id ]);
+                        if ( ( isset( $fields[ $field_id ] ) ) ) {
+                            $row_label = $fields[ $field_id ]->options[ 'choices' ][ $row_select_key ];
+                        }
+                    } else {
+                        $row_label = str_replace( '{' . $token . '}', $values[ $field_id ], $row_label );
+                    }
                 }
                 elseif ( false !== $fallback ) {
                      $row_label = str_replace( '{' . $token . '}', $fallback, $row_label );


### PR DESCRIPTION
Use select field current value as dynamic row label for Select type
fields.

This should just be a temporary solution: the dynamic field could work for (almost) any field.
But for now, this code should be enough for Select fields.