### PR TITLE
Confirm field ID when checking dynamic loop label source

### DIFF
--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -351,7 +351,7 @@ class cfs_loop extends cfs_field
                 $field_id = isset( $all_fields[ $field_name ] ) ? $all_fields[ $field_name ] : false;
 
                 if ( isset( $values[ $field_id ] ) ) {
-                    if ( 'select' == $field->type ) {
+                    if ( $field_id == $field->id && 'select' == $field->type ) {
                         $select_key = reset( $values[ $field_id ] );
                         if ( isset( $fields[ $field_id ] ) ) {
                             $row_label = $fields[ $field_id ]->options['choices'][ $select_key ];


### PR DESCRIPTION
Noticed after updating to 2.5.2 there was a Warning having to do with the change in dynamic labels:

![screen shot 2015-12-02 at 10 25 14 am](https://cloud.githubusercontent.com/assets/10412/11534872/1ef6665c-98df-11e5-80fd-81a66a861c64.png)

Looks like `$field` https://github.com/mgibbs189/custom-field-suite/blob/master/includes/fields/loop.php#L354 is left over from https://github.com/mgibbs189/custom-field-suite/blob/master/includes/fields/loop.php#L341-L343 which in my case is a `select` but it's the last field in my Loop.

My Loop is as such:

- Loop with dynamic field referencing first Text field name
    - Text (this is the field defining the Loop row label)
    - Text
    - Select

So `$field` still references the `select` when in fact it should be the first Text field. Checking for the field ID resolves the issue.