### PR TITLE
menu_position parameter added

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -58,6 +58,7 @@ class cfs_init
             'supports'          => array( 'title' ),
             'menu_icon'         => 'dashicons-carrot',
             'query_var'         => false,
+            'menu_position'     => 120,
             'labels'            => array(
                 'name'                  => __( 'Field Groups', 'cfs' ),
                 'singular_name'         => __( 'Field Group', 'cfs' ),


### PR DESCRIPTION
I added menu_position parameter to put admin menu item below second separator, after the Settings menu like most of the other plugins. It is sometimes confusing to see this between custom post types.