### PR TITLE
Allow Tabs in separate Field Groups to be active simultaneously

### DIFF
--- a/includes/fields/tab.php
+++ b/includes/fields/tab.php
@@ -27,15 +27,18 @@ class cfs_tab extends cfs_field
         <script>
         (function($) {
             $(document).on('click', '.cfs-tab', function() {
-                var tab = $(this).attr('rel');
-                $('.cfs-tab').removeClass('active');
-                $('.cfs-tab-content').removeClass('active');
+                var tab = $(this).attr('rel'),
+                    $context = $(this).parents('.cfs_input');
+                $context.find('.cfs-tab').removeClass('active');
+                $context.find('.cfs-tab-content').removeClass('active');
                 $(this).addClass('active');
-                $('.cfs-tab-content-' + tab).addClass('active');
+                $context.find('.cfs-tab-content-' + tab).addClass('active');
             });
 
             $(function() {
-                $('.cfs-tab:first').click();
+                $('.cfs-tabs').each(function(){
+                    $(this).find('.cfs-tab:first').click();
+                });
             });
         })(jQuery);
         </script>


### PR DESCRIPTION
If you have Tab fields in two separate Field Groups on the same page, you can only have one tab from any Field Group open at a time. This change makes it so one Tab from each Field Group may be active at a given time.