### PR TITLE
Hide tab note if not set; small style improvements

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -339,23 +339,34 @@
 .cfs-tabs {
     display: block;
     border-bottom: 1px solid #ccc;
-    margin: 20px 0 5px;
+	background: #FAFAFA;
+    margin: 0 0 5px;
+	padding-top: 10px;
 }
 
 .cfs-tab {
+	position: relative;
     display: inline-block;
     padding: 5px 15px;
     margin-left: 10px;
     margin-bottom: -1px;
     border: 1px solid #ccc;
-    background-color: #f5f5f5;
+    background-color: #f3f3f3;
     cursor: pointer;
-    border-radius: 1px 1px 0 0;
+    border-radius: 2px 1px 0 0;
 }
 
 .cfs-tab.active {
     background-color: #fff;
-    border-bottom: 1px solid #fff;
+}
+
+.cfs-tab.active:after {
+	content: '';
+	position: absolute;
+	right: 0;
+	bottom: -2px;
+	left: 0;
+	border-bottom: 4px solid #fff;
 }
 
 .cfs-tab-content {

--- a/includes/form.php
+++ b/includes/form.php
@@ -354,7 +354,10 @@ CFS['loop_buffer'] = [];
                         echo '</div>';
                     }
                     echo '<div class="cfs-tab-content cfs-tab-content-' . $field->name . '">';
-                    echo '<div class="cfs-tab-notes">' . esc_html( $field->notes ) . '</div>';
+
+					if ( ! empty( $field->notes ) ) {
+						echo '<div class="cfs-tab-notes">' . esc_html( $field->notes ) . '</div>';
+					}
                 }
                 else {
     ?>


### PR DESCRIPTION
I've made small tweaks to the tab styles (making the way the bottom border is hidden more consistent across browsers, thanks to the power of pseudo-elements), and set it so the tab note isn't inserted if it's empty.

Before:

![add_new_post_ _natrespro_ _wordpress](https://cloud.githubusercontent.com/assets/1231306/13495790/b072ca84-e11a-11e5-97df-c55945df7a9d.png)

After:

![add_new_post_ _natrespro_ _wordpress](https://cloud.githubusercontent.com/assets/1231306/13495805/c35edae8-e11a-11e5-976a-3dce66f4b7b2.png)

How it looks when there's a field above the tabs:

![add_new_post_ _natrespro_ _wordpress](https://cloud.githubusercontent.com/assets/1231306/13495879/22461e68-e11b-11e5-88f5-a0e893a47a4f.png)
