### PR TITLE
Use 12px gutters to match core

### DIFF
--- a/assets/css/fields.css
+++ b/assets/css/fields.css
@@ -27,7 +27,7 @@
 }
 
 #cfs_fields .table_footer {
-    padding: 10px;
+    padding: 10px 12px;
     text-align: right;
 }
 
@@ -89,6 +89,7 @@
 .field_meta table {
     border: 0;
     border-radius: 0;
+	border-spacing: 0;
 }
 
 .field_meta td {
@@ -131,10 +132,11 @@
     width: 100%;
     border: none;
     border-radius: 0;
+	border-spacing: 0;
 }
 
 .field_form td {
-    padding: 10px;
+    padding: 10px 12px;
 }
 
 .field_form td.label {
@@ -158,8 +160,9 @@
 }
 
 .field_form tr.field_basics table {
-    padding: 10px;
+    padding: 10px 12px;
     border-bottom: 1px solid #dfdfdf;
+	border-spacing: 0;
 }
 
 .field_form tr.field_basics td {
@@ -231,7 +234,7 @@ span.cfs_delete_field:hover {
 
 #cfs_rules table td,
 #cfs_extras table td {
-    padding: 10px;
+    padding: 10px 12px;
     border-top: 1px solid #fff;
     border-bottom: 1px solid #dfdfdf;
 }

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -8,7 +8,7 @@
 }
 
 .cfs_input .field {
-    padding: 10px;
+    padding: 10px 12px;
     border-top: 1px solid #fff;
     border-bottom: 1px solid #dfdfdf;
 }
@@ -313,7 +313,7 @@
 }
 
 .cfs_loop .cfs_loop_body {
-    padding: 10px;
+    padding: 10px 12px;
     background: #f8f8f8;
     display: none;
 }
@@ -345,7 +345,7 @@
 .cfs-tab {
     display: inline-block;
     padding: 5px 15px;
-    margin-left: 10px;
+    margin-left: 12px;
     margin-bottom: -1px;
     border: 1px solid #ccc;
     background-color: #f5f5f5;
@@ -367,7 +367,7 @@
 }
 
 .cfs-tab-notes {
-    padding: 10px;
+    padding: 10px 12px;
 }
 
 /*---------------------------------------------------------------------------------------------


### PR DESCRIPTION
WP core metaboxes now use 12px gutters. CFS still uses 10px gutters.

This pull request fixes that!

I also applied a border-spacing fix to tables in the field editor.