### PR TITLE
New `set` public API call

### DIFF
--- a/cfs.php
+++ b/cfs.php
@@ -49,6 +49,9 @@ class Custom_Field_Suite
         return CFS()->api->get( $field_name, $post_id, $options );
     }
 
+    function set( $post_id, $field_name, $field_value ) {
+        return CFS()->api->set( $post_id, $field_name, $field_value );
+    }
 
     function get_field_info( $field_name = false, $post_id = false ) {
         return CFS()->api->get_field_info( $field_name, $post_id );

--- a/includes/api.php
+++ b/includes/api.php
@@ -19,6 +19,16 @@ class cfs_api
         return $this->get_fields( $post_id, $options );
     }
 
+    /*
+    ================================================================
+        Abstraction for save_fields for specific post and field
+    ================================================================
+    */
+    public function set( $post_id, $field_name, $field_value ) {
+        $field_data = $this->get( false, $post_id, array( 'format' => 'raw' ) );
+        $field_data[$field_name] = $field_value;
+        $this->save_fields( $field_data, array( 'ID' => $post_id ) );
+    }
 
     /*
     ================================================================


### PR DESCRIPTION
A useful `set` method that could be used by developers to quickly set a value for a specific field for a specific post. Needs testing.