### PR TITLE
use JavaScript hrefs to add loop move/delete buttons to the tabindex

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -246,7 +246,7 @@
     width: 21px;
     height: 18px;
     text-decoration: none;
-	margin-right: -1px;
+    margin-right: -1px;
 }
 
 .cfs_toggle_field {
@@ -282,6 +282,7 @@
     cursor: pointer;
     display: inline-block;
     text-decoration: none;
+    border-radius: 50%;
 }
 
 .cfs_input .cfs_loop_toggle:before {

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -277,11 +277,11 @@
 
 .cfs_input .cfs_loop_toggle {
     float: right;
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
     cursor: pointer;
     display: inline-block;
-    margin-right: 6px;
+    text-decoration: none;
 }
 
 .cfs_input .cfs_loop_toggle:before {

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -243,20 +243,23 @@
 
 .cfs_delete_field {
     float: right;
-    width: 20px;
-    height: 16px;
+    width: 21px;
+    height: 18px;
+    text-decoration: none;
+	margin-right: -1px;
 }
 
 .cfs_toggle_field {
     float: right;
-    width: 16px;
-    height: 16px;
-    margin-right: 4px;
-    top:-1px;
+    width: 21px;
+    height: 18px;
+    text-decoration: none;
 }
 
 .cfs_toggle_field:before {
     content: '\f140';
+    position: relative;
+    top: -1px;
 }
 
 .open .cfs_toggle_field:before {

--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -75,7 +75,7 @@ class cfs_loop extends cfs_field
                 ?>
             </td>
         </tr>
-        
+
         <tr class="field_option field_option_<?php echo $this->name; ?>">
             <td class="label">
                 <label><?php _e( 'Limits', 'cfs' ); ?></label>
@@ -85,7 +85,7 @@ class cfs_loop extends cfs_field
                 <input type="text" name="cfs[fields][<?php echo $key; ?>][options][limit_max]" value="<?php echo $this->get_option( $field, 'limit_max' ); ?>" placeholder="max" style="width:60px" />
             </td>
         </tr>
-        
+
     <?php
     }
 
@@ -117,8 +117,8 @@ class cfs_loop extends cfs_field
     ?>
         <div class="loop_wrapper">
             <div class="cfs_loop_head open">
-                <a class="cfs_delete_field"></a>
-                <a class="cfs_toggle_field"></a>
+                <a class="cfs_delete_field" href="javascript:;"></a>
+                <a class="cfs_toggle_field" href="javascript:;"></a>
                 <span class="label"><?php echo esc_attr( $row_label ); ?></span>
             </div>
             <div class="cfs_loop_body open">
@@ -204,8 +204,8 @@ class cfs_loop extends cfs_field
     ?>
         <div class="loop_wrapper">
             <div class="cfs_loop_head<?php echo $css_class; ?>">
-                <a class="cfs_delete_field"></a>
-                <a class="cfs_toggle_field"></a>
+                <a class="cfs_delete_field" href="javascript:;"></a>
+                <a class="cfs_toggle_field" href="javascript:;"></a>
                 <span class="label"><?php echo esc_attr( $this->dynamic_label( $row_label, $results, $values[ $i ] ) ); ?>&nbsp;</span>
             </div>
             <div class="cfs_loop_body<?php echo $css_class; ?>">

--- a/includes/form.php
+++ b/includes/form.php
@@ -364,7 +364,7 @@ CFS['loop_buffer'] = [];
 
         <div class="field field-<?php echo $field->name; ?>" data-type="<?php echo $field->type; ?>" data-name="<?php echo $field->name; ?>"">
             <?php if ( 'loop' == $field->type ) : ?>
-            <span class="cfs_loop_toggle" title="<?php esc_html_e( 'Toggle row visibility', 'cfs' ); ?>"></span>
+            <a href="javascript:;" class="cfs_loop_toggle" title="<?php esc_html_e( 'Toggle row visibility', 'cfs' ); ?>"></a>
             <?php endif; ?>
 
             <?php if ( ! empty( $field->label ) ) : ?>


### PR DESCRIPTION
This feature uses `href="javascript:;"` attributes on loop field move/delete links, so they get added to the tabindex (and are thus accessible to keyboard users).

This is the "low-hanging fruit" fix referenced in issue #251.

This works fine with DOM changes and all that. It just follows the current state of the DOM. The only thing is that the tabindex gets reset if you delete or move the thing you're currently tabbed on. Not a huge deal though, as it's still better than it was before!