### PR TITLE
Update 'Hide the content editor' checkbox to new logic. Fixes #339

### DIFF
--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -23,7 +23,7 @@
         init_tooltip();
 
         // Setup checkboxes
-        $(document).on('click', 'input[type="checkbox"]', function() {
+        $(document).on('change click', 'input[type="checkbox"]', function() {
             var val = $(this).prop('checked') ? 1 : 0;
             $(this).siblings('input').val(val);
         });

--- a/assets/js/fields.js
+++ b/assets/js/fields.js
@@ -23,10 +23,9 @@
         init_tooltip();
 
         // Setup checkboxes
-        $(document).on('click', 'span.checkbox', function() {
-            var val = $(this).hasClass('active') ? 0 : 1;
+        $(document).on('click', 'input[type="checkbox"]', function() {
+            var val = $(this).prop('checked') ? 1 : 0;
             $(this).siblings('input').val(val);
-            $(this).toggleClass('active');
         });
 
         // Drag-and-drop support


### PR DESCRIPTION
There was some checkbox JavaScript logic that wasn't being applied to Field Group edit screens (but was working fine in post edit screen metaboxes) which prevented checkbox values from being properly changed/stored. This fixes that.