### PR TITLE
Allow multiple tokens in dynamic labels, and display formatted if dat…

### DIFF
--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -340,35 +340,51 @@ class cfs_loop extends cfs_field
 
         $field = false;
         $fallback = false;
-        $field_name = substr( $row_label, 1, -1 );
+        $format = false;
 
-        // Check for fallback value
-        if ( false !== strpos( $field_name, ':' ) ) {
-            list( $field_name, $fallback ) = explode( ':', $field_name );
-        }
+        $matches = array();
+        $tokens = array();
+        $replacements = array();
 
-        // Get all field names and IDs
-        foreach ( $fields as $f ) {
-            if ( $field_name == $f->name ) {
-                $field = $f;
-                break;
+        // Allow multiple dynamic tokens
+        preg_match_all ('/\{[^{]+\}/', $row_label, $matches, PREG_OFFSET_CAPTURE);
+
+        foreach ($matches[0] as $index => $match) {
+
+            $field_name = substr( $match[0], 1, -1 );
+            // Check for fallback value
+            if ( false !== strpos( $field_name, ':' ) ) {
+                list( $field_name, $fallback ) = explode( ':', $field_name );
+            }
+
+            // Get all field names and IDs
+            foreach ( $fields as $f ) {
+                if ( $field_name == $f->name ) {
+                    $field = $f;
+                    break;
+                }
+            }
+
+            if ( ! empty( $field ) && isset( $values[ $field->id ] ) ) {
+                $tokens[] = $match[0];
+                if ( 'select' == $field->type ) {
+                    $select_key = reset( $values[ $field->id ] );
+                    $replacements[] = $field->options['choices'][ $select_key ];
+                }
+                elseif ( 'date' == $field->type ) {
+                    // If it's a date field, display formated date
+                    $replacements[] = date_i18n( get_option( 'date_format' ), strtotime($values[ $field->id ]) );
+                }
+                else {
+                    $replacements[] = $values[ $field->id ];
+                }
+            }
+            elseif ( false !== $fallback ) {
+                 $replacements[] = $fallback;
             }
         }
 
-        if ( ! empty( $field ) && isset( $values[ $field->id ] ) ) {
-            if ( 'select' == $field->type ) {
-                $select_key = reset( $values[ $field->id ] );
-                $row_label = $field->options['choices'][ $select_key ];
-            }
-            else {
-                $row_label = $values[ $field->id ];
-            }
-        }
-        elseif ( false !== $fallback ) {
-             $row_label = $fallback;
-        }
-
-        return $row_label;
+        return str_replace($tokens, $replacements, $row_label);
     }
 
 

--- a/includes/fields/tab.php
+++ b/includes/fields/tab.php
@@ -45,13 +45,19 @@ class cfs_tab extends cfs_field
                 makeInactive($context);
                 makeTabActive($(this), $context);
 
-                sessionStorage.setItem('<?=$sessionStoreKey;?>', $(this).attr('rel'));
+                if(typeof(Storage) !== "undefined") {
+                    sessionStorage.setItem('<?=$sessionStoreKey;?>', $(this).attr('rel'));
+                }
             });
 
             $(function() {
+                var lastActiveTabRel = null,
+                    el = [];
 
-                var lastActiveTabRel = sessionStorage.getItem('<?=$sessionStoreKey;?>'),
+                if(typeof(Storage) !== "undefined") {
+                    lastActiveTabRel = sessionStorage.getItem('<?=$sessionStoreKey;?>');
                     el = $('.cfs-tabs [rel="' + lastActiveTabRel +'"]');
+                }
 
                 if (lastActiveTabRel && el.length > 0) {
                     makeTabActive(el, el.parents('.cfs_input'));

--- a/includes/fields/tab.php
+++ b/includes/fields/tab.php
@@ -23,25 +23,46 @@ class cfs_tab extends cfs_field
 
     // Tab handling javascript
     function input_head( $field = null ) {
+        $sessionStoreKey = "wp.plugin.custom-field-suite.group-id.{$field->group_id}";
     ?>
         <script>
         (function($) {
+
+            var makeTabActive = function (tabEl, contextEl) {
+                tabEl.addClass('active');
+                contextEl.find('.cfs-tab-content-' + tabEl.attr('rel')).addClass('active');
+            };
+
+            var makeInactive = function (contextEl) {
+                contextEl.find('.cfs-tab').removeClass('active');
+                contextEl.find('.cfs-tab-content').removeClass('active');
+            };
+
             $(document).on('click', '.cfs-tab', function() {
-                var tab = $(this).attr('rel'),
-                    $context = $(this).parents('.cfs_input');
-                $context.find('.cfs-tab').removeClass('active');
-                $context.find('.cfs-tab-content').removeClass('active');
-                $(this).addClass('active');
-                $context.find('.cfs-tab-content-' + tab).addClass('active');
+
+                var $context = $(this).parents('.cfs_input');
+
+                makeInactive($context);
+                makeTabActive($(this), $context);
+
+                sessionStorage.setItem('<?=$sessionStoreKey;?>', $(this).attr('rel'));
             });
 
             $(function() {
-                $('.cfs-tabs').each(function(){
-                    $(this).find('.cfs-tab:first').click();
-                });
+
+                var lastActiveTabRel = sessionStorage.getItem('<?=$sessionStoreKey;?>'),
+                    el = $('.cfs-tabs [rel="' + lastActiveTabRel +'"]');
+
+                if (lastActiveTabRel && el.length > 0) {
+                    makeTabActive(el, el.parents('.cfs_input'));
+                } else {
+                    var firstTab = $('.cfs-tab:first');
+                    makeTabActive(firstTab, firstTab.parents('.cfs_input'));
+                }
+
             });
+
         })(jQuery);
         </script>
     <?php
-    }
 }


### PR DESCRIPTION
Hi mgibbs189,

I've made the dynamic labels accept multiple field tokens instead of just one, and if it is a date type field, then auto format date with WP's `date_i18n();` function.

Rationale and use case example. A performer's website, who may perform at a venue multiple times on different dates. Instead of only showing dynamic label for, as an example, the {venue}. With support for multiple dynamic tokens, it can be `{date} - {venue}`, result `Jun 1, 2016 - Foo Music Venue`

Or if it's a loop field with contact data, instead of displaying only the name or only the email, it can be
`{contact_person}, {contact_email}`

The downside is if someone were to use many tokens, on a long list of fields, it would slow down loading.

I believe being able to display just one additional field's value dynamically makes each row knowable without needed to expand the row, I really hope this will be added to the main plugin, either directly or if you prefer to code it a different way.

Thank you very much for this plugin, I really like it, it is simple to use and understand.

With kind regards,
Edward Hew