### PR TITLE
Introduce the ability to insert a loop row inline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -304,6 +304,20 @@
     margin-bottom: 10px;
 }
 
+@keyframes highlight {
+	0% {
+		box-shadow: 0 0 3px 1px rgba(255,255,0,0.4);
+	}
+
+	100% {
+		box-shadow: 0 0 3px 1px rgba(255,255,0,0);
+	}
+}
+
+.cfs_loop .loop_wrapper_new {
+	animation: highlight 1s ease-in-out;
+}
+
 .cfs_loop .cfs_loop_head {
     cursor: pointer;
     padding: 5px 5px 5px 30px;

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -305,17 +305,17 @@
 }
 
 @keyframes highlight {
-	0% {
-		box-shadow: 0 0 3px 1px rgba(255,255,0,0.4);
-	}
+    0% {
+        box-shadow: 0 0 3px 1px rgba(255,255,0,0.4);
+    }
 
-	100% {
-		box-shadow: 0 0 3px 1px rgba(255,255,0,0);
-	}
+    100% {
+        box-shadow: 0 0 3px 1px rgba(255,255,0,0);
+    }
 }
 
 .cfs_loop .loop_wrapper_new {
-	animation: highlight 1s ease-in-out;
+    animation: highlight 1s ease-in-out;
 }
 
 .cfs_loop .cfs_loop_head {

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -262,6 +262,10 @@
     top: -1px;
 }
 
+.open .cfs_toggle_field:before {
+    content: '\f142';
+}
+
 .cfs_insert_field {
     float: right;
     width: 21px;

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -306,16 +306,16 @@
 
 @keyframes highlight {
     0% {
-        box-shadow: 0 0 3px 1px rgba(255,255,0,0.4);
+        box-shadow: 0 0 5px 1px rgba(255,255,0,0.8);
     }
 
     100% {
-        box-shadow: 0 0 3px 1px rgba(255,255,0,0);
+        box-shadow: 0 0 5px 1px rgba(255,255,0,0);
     }
 }
 
 .cfs_loop .loop_wrapper_new {
-    animation: highlight 1s ease-in-out;
+    animation: highlight 1.5s ease-in-out;
 }
 
 .cfs_loop .cfs_loop_head {

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -262,8 +262,17 @@
     top: -1px;
 }
 
-.open .cfs_toggle_field:before {
-    content: '\f142';
+.cfs_insert_field {
+    float: right;
+    width: 21px;
+    height: 18px;
+    text-decoration: none;
+}
+
+.loop_wrapper:hover .cfs_insert_field:before {
+    content: '\f132';
+    position: relative;
+    top: 0px;
 }
 
 .cfs_input .cfs_loop label {
@@ -396,6 +405,7 @@
 .cfs_input .cfs_loop_toggle,
 .cfs_input .cfs_toggle_field,
 .cfs_input .cfs_delete_field,
+.cfs_input .cfs_insert_field,
 .cfs_relationship .selected_posts div span.remove,
 .cfs_user .selected_posts div span.remove,
 .cfs_relationship .cfs_filter_help,
@@ -406,6 +416,7 @@
 .cfs_input .cfs_loop_toggle:before,
 .cfs_input .cfs_toggle_field:before,
 .cfs_input .cfs_delete_field:before,
+.cfs_input .cfs_insert_field:before,
 .cfs_loop .cfs_loop_head:before,
 .cfs_relationship .selected_posts div span.remove:before,
 .cfs_user .selected_posts div span.remove:before,

--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -119,6 +119,7 @@ class cfs_loop extends cfs_field
             <div class="cfs_loop_head open">
                 <a class="cfs_delete_field" href="javascript:;"></a>
                 <a class="cfs_toggle_field" href="javascript:;"></a>
+                <a class="cfs_insert_field" href="javascript:;"></a>
                 <span class="label"><?php echo esc_attr( $row_label ); ?></span>
             </div>
             <div class="cfs_loop_body open">
@@ -206,6 +207,7 @@ class cfs_loop extends cfs_field
             <div class="cfs_loop_head<?php echo $css_class; ?>">
                 <a class="cfs_delete_field" href="javascript:;"></a>
                 <a class="cfs_toggle_field" href="javascript:;"></a>
+                <a class="cfs_insert_field" href="javascript:;"></a>
                 <span class="label"><?php echo esc_attr( $this->dynamic_label( $row_label, $results, $values[ $i ] ) ); ?>&nbsp;</span>
             </div>
             <div class="cfs_loop_body<?php echo $css_class; ?>">
@@ -269,6 +271,18 @@ class cfs_loop extends cfs_field
                     $(this).attr('data-rows', parseInt(num_rows)+1);
                     $(this).closest('.table_footer').before(html);
                     $(this).trigger('cfs/ready');
+                });
+
+                $(document).on('click', '.cfs_insert_field', function(event) {
+                    event.stopPropagation();
+					var $add_field = $('.cfs_add_field');
+                    var num_rows = $add_field.attr('data-rows');
+                    var loop_tag = $add_field.attr('data-loop-tag');
+                    var loop_id = loop_tag.match(/.*\[(.*?)\]/)[1];
+                    var html = CFS.loop_buffer[loop_id].replace(/\[clone\]/g, loop_tag + '[' + num_rows + ']');
+                    $add_field.attr('data-rows', parseInt(num_rows)+1);
+                    $(this).closest('.loop_wrapper').after(html);
+                    $add_field.trigger('cfs/ready');
                 });
 
                 $(document).on('click', '.cfs_delete_field', function(event) {

--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -269,7 +269,7 @@ class cfs_loop extends cfs_field
                     var loop_id = loop_tag.match(/.*\[(.*?)\]/)[1];
                     var html = CFS.loop_buffer[loop_id].replace(/\[clone\]/g, loop_tag + '[' + num_rows + ']');
                     $(this).attr('data-rows', parseInt(num_rows)+1);
-                    $(this).closest('.table_footer').before(html);
+					$(html).insertBefore( $(this).closest('.table_footer') ).addClass('loop_wrapper_new');
                     $(this).trigger('cfs/ready');
                 });
 
@@ -281,7 +281,7 @@ class cfs_loop extends cfs_field
                     var loop_id = loop_tag.match(/.*\[(.*?)\]/)[1];
                     var html = CFS.loop_buffer[loop_id].replace(/\[clone\]/g, loop_tag + '[' + num_rows + ']');
                     $add_field.attr('data-rows', parseInt(num_rows)+1);
-                    $(this).closest('.loop_wrapper').after(html);
+					$(html).insertAfter( $(this).closest('.loop_wrapper') ).addClass('loop_wrapper_new');
                     $add_field.trigger('cfs/ready');
                 });
 

--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -269,19 +269,19 @@ class cfs_loop extends cfs_field
                     var loop_id = loop_tag.match(/.*\[(.*?)\]/)[1];
                     var html = CFS.loop_buffer[loop_id].replace(/\[clone\]/g, loop_tag + '[' + num_rows + ']');
                     $(this).attr('data-rows', parseInt(num_rows)+1);
-					$(html).insertBefore( $(this).closest('.table_footer') ).addClass('loop_wrapper_new');
+                    $(html).insertBefore( $(this).closest('.table_footer') ).addClass('loop_wrapper_new');
                     $(this).trigger('cfs/ready');
                 });
 
                 $(document).on('click', '.cfs_insert_field', function(event) {
                     event.stopPropagation();
-					var $add_field = $('.cfs_add_field');
+                    var $add_field = $('.cfs_add_field');
                     var num_rows = $add_field.attr('data-rows');
                     var loop_tag = $add_field.attr('data-loop-tag');
                     var loop_id = loop_tag.match(/.*\[(.*?)\]/)[1];
                     var html = CFS.loop_buffer[loop_id].replace(/\[clone\]/g, loop_tag + '[' + num_rows + ']');
                     $add_field.attr('data-rows', parseInt(num_rows)+1);
-					$(html).insertAfter( $(this).closest('.loop_wrapper') ).addClass('loop_wrapper_new');
+                    $(html).insertAfter( $(this).closest('.loop_wrapper') ).addClass('loop_wrapper_new');
                     $add_field.trigger('cfs/ready');
                 });
 


### PR DESCRIPTION
### Summary

This PR introduces a new feature: the ability to insert a new loop row at any given point within a set of rows.

#357 requested the ability to add a row to the top of a set of loop rows. This PR doesn't specifically allow that, but it does allow you to insert a loop row _almost_ at the top, which is pretty close. This eliminates the need to do long drag-and-drops, which can get complex especially on smaller screens. If you need to insert an element at the top, you now only need to drag it over one row instead of many.

### Preview

_**Edit:** See first comment below for most recent animation._

![recording-13-encoded](https://cloud.githubusercontent.com/assets/1231306/18148199/37d4224c-6fa6-11e6-8247-383045ed1998.gif)

### Implementation Notes

The JavaScript steals from the JS for the `.cfs_add_field` button. I essentially copied/pasted and changed the DOM targets, and this could probably be abstracted slightly to improve code reuse.

Also, it slightly bothers me that the Dashicons "plus" sign icon is slightly larger/thicker than the close button, but that's a Dashicons limitation. Open to exploring alternate style options.

That's partially why this implementation hides the icon unless your mouse hovers over the row. I also feel that it makes it less immediately overwhelming.