### PR TITLE
[WIP / RFC] Improve inline validation error handling

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -52,10 +52,12 @@
 }
 
 .cfs_input .error {
-    padding: 5px;
+    padding: 7px 10px;
     margin: 5px 0;
     background: #ffebe8;
-    border: 1px solid #c00;
+    border: 1px solid #dcc6d7;
+    border-left: 4px solid #dc3232;
+    font-weight: bold;
 }
 
 .hidden {

--- a/assets/js/validation.js
+++ b/assets/js/validation.js
@@ -132,11 +132,11 @@
                                 if ('function' == typeof error_msg) {
                                     error_msg = error_msg($this);
                                 }
+
                                 $this.find('.error').html(error_msg);
                                 $this.find('.error').show();
-                                $('html, body').animate({
-                                    scrollTop: $this.find('.error').offset().top
-                                }, 500);
+
+                                $('#cfs-validation-admin-notice').show();
                             }
                         }
                     });

--- a/assets/js/validation.js
+++ b/assets/js/validation.js
@@ -120,6 +120,13 @@
                                     $this.append('<div class="error"></div>');
                                 }
 
+                                // if the error is inside a loop field, open it up
+                                if ($this.parents('.cfs_loop_body').length > 0) {
+                                    $loop = $this.parents('.cfs_loop_body');
+                                    $loop.addClass('open');
+                                    $loop.siblings('.cfs_loop_head').addClass('open');
+                                }
+
                                 // error can be either a string or function
                                 var error_msg = CFS.validators[validator]['error'];
                                 if ('function' == typeof error_msg) {

--- a/includes/form.php
+++ b/includes/form.php
@@ -180,7 +180,7 @@ CFS['loop_buffer'] = [];
     /**
      * Add an admin notice to be displayed in the event of
      * validation errors
-     * @since
+     * @since 2.6
      */
     function admin_notice() {
         $screen = get_current_screen();

--- a/includes/form.php
+++ b/includes/form.php
@@ -15,6 +15,7 @@ class cfs_form
         add_action( 'init', array( $this, 'init' ), 100 );
         add_action( 'admin_head', array( $this, 'head_scripts' ) );
         add_action( 'admin_print_footer_scripts', array( $this, 'footer_scripts' ) );
+        add_action( 'admin_notices', array( $this, 'admin_notice' ) );
     }
 
 
@@ -173,6 +174,24 @@ CFS['loop_buffer'] = [];
      */
     function footer_scripts() {
         do_action( 'cfs_custom_validation' );
+    }
+
+
+    /**
+     * Add an admin notice to be displayed in the event of
+     * validation errors
+     * @since
+     */
+    function admin_notice() {
+        $screen = get_current_screen();
+
+        if ( !isset($screen->base) || $screen->base !== 'post' ) {
+            return;
+        }
+
+        echo '<div class="notice notice-error" id="cfs-validation-admin-notice" style="display: none;"><p><strong>';
+        echo __( 'One (or more) of your fields had validation errors. More information is available below.', 'cfs' );
+        echo '</strong></p></div>';
     }
 
 


### PR DESCRIPTION
This is a work-in-progress pull request. Exploring a few ideas related to improved inline validation error handling.

Ideas:
- [x] If there's an error inside the loop row, the loop row should open to reveal it
- [x] Add a proper WordPressy admin notice in the event of an error
- [x] Don't scroll down to each error (an admin notice at the top should prevent the "why isn't it saving?" confusion)
- [x] Style the inline errors to be more WordPressy

Would love thoughts, feedback, and ideas!
