### PR TITLE
Improve page selection in the rules metabox

### DIFF
--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -32,12 +32,12 @@ class cfs_ajax
                 absint( $result->post_parent ) > 0 &&
                 $parent = get_post( $result->post_parent )
             ) {
-                $parent = "$parent->post_title /";
+                $parent = "$parent->post_title >";
             }
 
             $output[] = array(
                 'id' => $result->ID,
-                'text' => "($result->post_type) $parent $result->post_title"
+                'text' => "($result->post_type) $parent $result->post_title (#$result->ID)"
             );
         }
         return json_encode( $output );

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -4,14 +4,14 @@ class cfs_ajax
 {
     /**
      * Search posts (in the Placement Rules area)
-     * @param array $options 
+     * @param array $options
      * @return string A JSON results object
      */
     public function search_posts( $options ) {
         global $wpdb;
 
         $sql = $wpdb->prepare("
-        SELECT ID, post_type, post_title
+        SELECT ID, post_type, post_title, post_parent
         FROM $wpdb->posts
         WHERE
             post_status IN ('publish', 'private') AND
@@ -25,9 +25,19 @@ class cfs_ajax
 
         $output = array();
         foreach ( $results as $result ) {
+            $parent = '';
+
+            if (
+                isset( $result->post_parent ) &&
+                absint( $result->post_parent ) > 0 &&
+                $parent = get_post( $result->post_parent )
+            ) {
+                $parent = "$parent->post_title /";
+            }
+
             $output[] = array(
                 'id' => $result->ID,
-                'text' => "($result->post_type) $result->post_title"
+                'text' => "($result->post_type) $parent $result->post_title"
             );
         }
         return json_encode( $output );

--- a/templates/meta_box_rules.php
+++ b/templates/meta_box_rules.php
@@ -57,14 +57,24 @@ if ( ! empty( $rules['post_ids']['values'] ) ) {
     $post_in = implode( ',', $rules['post_ids']['values'] );
 
     $sql = "
-    SELECT ID, post_type, post_title
+    SELECT ID, post_type, post_title, post_parent
     FROM $wpdb->posts
     WHERE ID IN ($post_in)
     ORDER BY post_type, post_title";
     $results = $wpdb->get_results( $sql );
 
     foreach ( $results as $result ) {
-        $json_posts[] = array( 'id' => $result->ID, 'text' => "($result->post_type) $result->post_title" );
+        $parent = '';
+
+        if (
+            isset( $result->post_parent ) &&
+            absint( $result->post_parent ) > 0 &&
+            $parent = get_post( $result->post_parent )
+        ) {
+            $parent = "$parent->post_title /";
+        }
+
+        $json_posts[] = array( 'id' => $result->ID, 'text' => "($result->post_type) $parent $result->post_title" );
         $post_ids[] = $result->ID;
     }
 }

--- a/templates/meta_box_rules.php
+++ b/templates/meta_box_rules.php
@@ -71,10 +71,10 @@ if ( ! empty( $rules['post_ids']['values'] ) ) {
             absint( $result->post_parent ) > 0 &&
             $parent = get_post( $result->post_parent )
         ) {
-            $parent = "$parent->post_title /";
+            $parent = "$parent->post_title >";
         }
 
-        $json_posts[] = array( 'id' => $result->ID, 'text' => "($result->post_type) $parent $result->post_title" );
+        $json_posts[] = array( 'id' => $result->ID, 'text' => "($result->post_type) $parent $result->post_title (#$result->ID)" );
         $post_ids[] = $result->ID;
     }
 }


### PR DESCRIPTION
I'm working on a project with a lot of page/post names that are repeated. It's tough to tell which version of "Wizard" belongs to which parent post (for instance).

This is a PR that improves that.

![edit_field_group_ _ecommercefuel_directories_ _wordpress](https://cloud.githubusercontent.com/assets/1231306/18762095/6971ffa0-80d5-11e6-81f3-5a4f1f51f3fe.jpg)

This is a work in progress. Here's what I'm working on:

- [x] Initial attempt to display page hierarchy
- [ ] ~~Support for multiple levels of hierarchy~~

Here's what I'd love feedback on:

1. Should the page ID be included in the results as well?
2. Should this be filterable, so users can customise it? Something like `cfs_meta_box_rules_posts_text` with the post ID and stdClass `$result` as additional arguments?
3. If we go with a filter, should this (hierarchical display) be included at all by default, or moved to a separate plugin?

Thanks!