### PR TITLE
Introducing: Term field

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -143,6 +143,7 @@
 ---------------------------------------------------------------------------------------------*/
 
 .cfs_relationship .post_list,
+.cfs_term .post_list,
 .cfs_user .post_list {
     float: left;
     overflow-y: scroll;
@@ -157,11 +158,13 @@
 }
 
 .cfs_relationship .post_list.selected_posts,
+.cfs_term .post_list.selected_posts,
 .cfs_user .post_list.selected_posts {
     float: right;
 }
 
 .cfs_relationship .post_list div,
+.cfs_term .post_list div,
 .cfs_user .post_list div {
     padding: 4px 6px;
     border-bottom: 1px solid #eee;
@@ -169,12 +172,14 @@
 }
 
 .cfs_relationship .post_list.available_posts > div,
+.cfs_term .post_list.available_posts > div,
 .cfs_user .post_list.available_posts > div {
     position: relative;
     padding-right: 3em;
 }
 
 .cfs_relationship .post_list.available_posts > div:after,
+.cfs_term .post_list.available_posts > div:after,
 .cfs_user .post_list.available_posts > div:after {
     position: absolute;
     right: 1px;
@@ -184,26 +189,31 @@
 }
 
 .cfs_relationship .post_list div:last-child,
+.cfs_term .post_list div:last-child,
 .cfs_user .post_list div:last-child {
     border-bottom: none;
 }
 
 .cfs_relationship .post_list div:hover,
+.cfs_term .post_list div:hover,
 .cfs_user .post_list div:hover {
     background: #eee;
 }
 
 .cfs_relationship .available_posts div.used,
+.cfs_term .available_posts div.used,
 .cfs_user .available_posts div.used{
     display: none;
 }
 
 .cfs_relationship .selected_posts div,
+.cfs_term .selected_posts div,
 .cfs_user .selected_posts div {
     cursor: move;
 }
 
 .cfs_relationship .selected_posts div span.remove,
+.cfs_term .selected_posts div span.remove,
 .cfs_user .selected_posts div span.remove {
     float: right;
     width: 20px;
@@ -212,17 +222,20 @@
 }
 
 .cfs_relationship .filter_posts,
+.cfs_term .filter_posts,
 .cfs_user .filter_posts {
     margin-bottom: 10px;
 }
 
 .cfs_input .field .cfs_relationship .cfs_filter_input,
+.cfs_input .field .cfs_term .cfs_filter_input,
 .cfs_input .field .cfs_user .cfs_filter_input{
     width: 220px;
     margin: 0;
 }
 
 .cfs_relationship .cfs_filter_help,
+.cfs_term .cfs_filter_help,
 .cfs_user .cfs_filter_help {
     display: inline-block;
     width: 20px;
@@ -232,6 +245,7 @@
 }
 
 .cfs_relationship .cfs_filter_help:before,
+.cfs_term .cfs_filter_help:before,
 .cfs_user .cfs_filter_help:before {
     content: '\f348';
 }
@@ -425,8 +439,10 @@
 .cfs_input .cfs_delete_field,
 .cfs_input .cfs_insert_field,
 .cfs_relationship .selected_posts div span.remove,
+.cfs_term .selected_posts div span.remove,
 .cfs_user .selected_posts div span.remove,
 .cfs_relationship .cfs_filter_help,
+.cfs_term .cfs_filter_help,
 .cfs_user .cfs_filter_help{
     position: relative;
 }
@@ -437,11 +453,13 @@
 .cfs_input .cfs_insert_field:before,
 .cfs_loop .cfs_loop_head:before,
 .cfs_relationship .selected_posts div span.remove:before,
-.cfs_user .selected_posts div span.remove:before,
+.cfs_term .selected_posts div span.remove:before,
 .cfs_user .selected_posts div span.remove:before,
 .cfs_relationship .cfs_filter_help:before,
+.cfs_term .cfs_filter_help:before,
 .cfs_user .cfs_filter_help:before,
 .cfs_relationship .post_list.available_posts > div:after,
+.cfs_term .post_list.available_posts > div:after,
 .cfs_user .post_list.available_posts > div:after {
     display: block;
     position: absolute;
@@ -463,6 +481,7 @@
 
 .cfs_input .cfs_delete_field:before,
 .cfs_relationship .selected_posts div span.remove:before,
+.cfs_term .selected_posts div span.remove:before,
 .cfs_user .selected_posts div span.remove:before {
     content: '\f335';
     font-size: 22px;

--- a/assets/js/validation.js
+++ b/assets/js/validation.js
@@ -58,6 +58,9 @@
             'relationship': function(el) {
                 return el.find('input.relationship').val();
             },
+            'term': function(el) {
+                return el.find('input.term').val();
+            },
             'user': function(el) {
                 return el.find('input.user').val();
             },

--- a/includes/fields/term.php
+++ b/includes/fields/term.php
@@ -12,8 +12,8 @@ class cfs_term extends cfs_field
     function html( $field ) {
         global $wpdb;
 
-        $selected_terms = array();
-        $available_terms = array();
+        $selected_posts = array();
+        $available_posts = array();
 
         $taxonomies = array();
         if ( ! empty( $field->options['taxonomies'] ) ) {
@@ -22,11 +22,11 @@ class cfs_term extends cfs_field
             }
         }
         else {
-            $post_types = get_taxonomies( array( 'public' => true ) );
+            $taxonomies = get_taxonomies( array( 'public' => true ) );
         }
 
         $args = array(
-            'taxonomy'   => $post_types,
+            'taxonomy'   => $taxonomies,
             'hide_empty' => false,
             'fields'     => 'ids',
             'orderby'    => 'name',
@@ -38,7 +38,7 @@ class cfs_term extends cfs_field
 
         foreach ( $query->terms as $term_id ) {
             $term = get_term( $term_id );
-            $available_terms[] = (object) array(
+            $available_posts[] = (object) array(
                 'term_id'  => $term->term_id,
                 'taxonomy' => $term->taxonomy,
                 'name'     => $term->name,
@@ -48,23 +48,23 @@ class cfs_term extends cfs_field
         if ( ! empty( $field->value ) ) {
             $results = $wpdb->get_results( "SELECT term_id, name FROM $wpdb->terms WHERE term_id IN ($field->value) ORDER BY FIELD(term_id,$field->value)" );
             foreach ( $results as $result ) {
-                $selected_terms[ $result->term_id ] = $result;
+                $selected_posts[ $result->term_id ] = $result;
             }
         }
     ?>
-        <div class="filter_terms">
+        <div class="filter_posts">
             <input type="text" class="cfs_filter_input" autocomplete="off" placeholder="<?php _e( 'Search terms', 'cfs' ); ?>" />
         </div>
 
-        <div class="available_terms term_list">
-        <?php foreach ( $available_terms as $term ) : ?>
-            <?php $class = ( isset( $selected_terms[ $term->term_id ] ) ) ? ' class="used"' : ''; ?>
+        <div class="available_posts post_list">
+        <?php foreach ( $available_posts as $term ) : ?>
+            <?php $class = ( isset( $selected_posts[ $term->term_id ] ) ) ? ' class="used"' : ''; ?>
             <div rel="<?php echo $term->term_id; ?>"<?php echo $class; ?> title="<?php echo $term->name; ?>"><?php echo apply_filters( 'cfs_term_display', $term->name, $term->term_id, $field ); ?></div>
         <?php endforeach; ?>
         </div>
 
-        <div class="selected_terms term_list">
-        <?php foreach ( $selected_terms as $term ) : ?>
+        <div class="selected_posts post_list">
+        <?php foreach ( $selected_posts as $term ) : ?>
             <div rel="<?php echo $term->term_id; ?>"><span class="remove"></span><?php echo apply_filters( 'cfs_term_display', $term->name, $term->term_id, $field ); ?></div>
         <?php endforeach; ?>
         </div>
@@ -114,10 +114,10 @@ class cfs_term extends cfs_field
         (function($) {
             update_term_values = function(field) {
                 var term_ids = [];
-                field.find('.selected_terms div').each(function(idx) {
+                field.find('.selected_posts div').each(function(idx) {
                     term_ids[idx] = $(this).attr('rel');
                 });
-                field.find('input.terms').val(term_ids.join(','));
+                field.find('input.term').val(term_ids.join(','));
             }
 
             $(function() {
@@ -127,21 +127,21 @@ class cfs_term extends cfs_field
                 $('.cfs_term').init_term();
 
                 // add selected post
-                $(document).on('click', '.cfs_term .available_terms div', function() {
+                $(document).on('click', '.cfs_term .available_posts div', function() {
                     var parent = $(this).closest('.field');
                     var term_id = $(this).attr('rel');
                     var html = $(this).html();
                     $(this).addClass('used');
-                    parent.find('.selected_terms').append('<div rel="'+term_id+'"><span class="remove"></span>'+html+'</div>');
+                    parent.find('.selected_posts').append('<div rel="'+term_id+'"><span class="remove"></span>'+html+'</div>');
                     update_term_values(parent);
                 });
 
                 // remove selected post
-                $(document).on('click', '.cfs_term .selected_terms .remove', function() {
+                $(document).on('click', '.cfs_term .selected_posts .remove', function() {
                     var div = $(this).parent();
                     var parent = div.closest('.field');
                     var term_id = div.attr('rel');
-                    parent.find('.available_terms div[rel='+post_id+']').removeClass('used');
+                    parent.find('.available_posts div[rel='+post_id+']').removeClass('used');
                     div.remove();
                     update_term_values(parent);
                 });
@@ -151,7 +151,7 @@ class cfs_term extends cfs_field
                     var input = $(this).val();
                     var parent = $(this).closest('.field');
                     var regex = new RegExp(input, 'i');
-                    parent.find('.available_terms div:not(.used)').each(function() {
+                    parent.find('.available_posts div:not(.used)').each(function() {
                         if (-1 < $(this).html().search(regex)) {
                             $(this).removeClass('hidden');
                         }
@@ -168,7 +168,7 @@ class cfs_term extends cfs_field
                     $this.addClass('ready');
 
                     // sortable
-                    $this.find('.selected_terms').sortable({
+                    $this.find('.selected_posts').sortable({
                         axis: 'y',
                         update: function(event, ui) {
                             var parent = $(this).closest('.field');

--- a/includes/fields/term.php
+++ b/includes/fields/term.php
@@ -1,0 +1,212 @@
+<?php
+
+class cfs_term extends cfs_field
+{
+
+    function __construct() {
+        $this->name = 'term';
+        $this->label = __( 'Term', 'cfs' );
+    }
+
+
+    function html( $field ) {
+        global $wpdb;
+
+        $selected_terms = array();
+        $available_terms = array();
+
+        $taxonomies = array();
+        if ( ! empty( $field->options['taxonomies'] ) ) {
+            foreach ( $field->options['taxonomies'] as $taxonomy ) {
+                $taxonomies[] = $taxonomy;
+            }
+        }
+        else {
+            $post_types = get_taxonomies( array( 'public' => true ) );
+        }
+
+        $args = array(
+            'taxonomy'   => $post_types,
+            'hide_empty' => false,
+            'fields'     => 'ids',
+            'orderby'    => 'name',
+            'order'      => 'ASC'
+        );
+
+        $args = apply_filters( 'cfs_field_term_query_args', $args, array( 'field' => $field ) );
+        $query = new WP_Term_Query( $args );
+
+        foreach ( $query->terms as $term_id ) {
+            $term = get_term( $term_id );
+            $available_terms[] = (object) array(
+                'term_id'  => $term->term_id,
+                'taxonomy' => $term->taxonomy,
+                'name'     => $term->name,
+            );
+        }
+
+        if ( ! empty( $field->value ) ) {
+            $results = $wpdb->get_results( "SELECT term_id, name FROM $wpdb->terms WHERE term_id IN ($field->value) ORDER BY FIELD(term_id,$field->value)" );
+            foreach ( $results as $result ) {
+                $selected_terms[ $result->term_id ] = $result;
+            }
+        }
+    ?>
+        <div class="filter_terms">
+            <input type="text" class="cfs_filter_input" autocomplete="off" placeholder="<?php _e( 'Search terms', 'cfs' ); ?>" />
+        </div>
+
+        <div class="available_terms term_list">
+        <?php foreach ( $available_terms as $term ) : ?>
+            <?php $class = ( isset( $selected_terms[ $term->term_id ] ) ) ? ' class="used"' : ''; ?>
+            <div rel="<?php echo $term->term_id; ?>"<?php echo $class; ?> title="<?php echo $term->name; ?>"><?php echo apply_filters( 'cfs_term_display', $term->name, $term->term_id, $field ); ?></div>
+        <?php endforeach; ?>
+        </div>
+
+        <div class="selected_terms term_list">
+        <?php foreach ( $selected_terms as $term ) : ?>
+            <div rel="<?php echo $term->term_id; ?>"><span class="remove"></span><?php echo apply_filters( 'cfs_term_display', $term->name, $term->term_id, $field ); ?></div>
+        <?php endforeach; ?>
+        </div>
+        <div class="clear"></div>
+        <input type="hidden" name="<?php echo $field->input_name; ?>" class="<?php echo $field->input_class; ?>" value="<?php echo $field->value; ?>" />
+    <?php
+    }
+
+
+    function options_html( $key, $field ) {
+        $args = array( 'public' => true );
+        $choices = apply_filters( 'cfs_field_term_taxonomies', get_taxonomies( $args ) );
+
+    ?>
+        <tr class="field_option field_option_<?php echo $this->name; ?>">
+            <td class="label">
+                <label><?php _e('Taxonomies', 'cfs'); ?></label>
+                <p class="description"><?php _e('Limit terms to the following taxonomies', 'cfs'); ?></p>
+            </td>
+            <td>
+                <?php
+                    CFS()->create_field( array(
+                        'type'          => 'select',
+                        'input_name'    => "cfs[fields][$key][options][taxonomies]",
+                        'options'       => array( 'multiple' => '1', 'choices' => $choices ),
+                        'value'         => $this->get_option( $field, 'taxonomies' ),
+                    ));
+                ?>
+            </td>
+        </tr>
+        <tr class="field_option field_option_<?php echo $this->name; ?>">
+            <td class="label">
+                <label><?php _e( 'Limits', 'cfs' ); ?></label>
+            </td>
+            <td>
+                <input type="text" name="cfs[fields][<?php echo $key; ?>][options][limit_min]" value="<?php echo $this->get_option( $field, 'limit_min' ); ?>" placeholder="min" style="width:60px" />
+                <input type="text" name="cfs[fields][<?php echo $key; ?>][options][limit_max]" value="<?php echo $this->get_option( $field, 'limit_max' ); ?>" placeholder="max" style="width:60px" />
+            </td>
+        </tr>
+    <?php
+    }
+
+
+    function input_head( $field = null ) {
+    ?>
+        <script>
+        (function($) {
+            update_term_values = function(field) {
+                var term_ids = [];
+                field.find('.selected_terms div').each(function(idx) {
+                    term_ids[idx] = $(this).attr('rel');
+                });
+                field.find('input.terms').val(term_ids.join(','));
+            }
+
+            $(function() {
+                $(document).on('cfs/ready', '.cfs_add_field', function() {
+                    $('.cfs_term:not(.ready)').init_term();
+                });
+                $('.cfs_term').init_term();
+
+                // add selected post
+                $(document).on('click', '.cfs_term .available_terms div', function() {
+                    var parent = $(this).closest('.field');
+                    var term_id = $(this).attr('rel');
+                    var html = $(this).html();
+                    $(this).addClass('used');
+                    parent.find('.selected_terms').append('<div rel="'+term_id+'"><span class="remove"></span>'+html+'</div>');
+                    update_term_values(parent);
+                });
+
+                // remove selected post
+                $(document).on('click', '.cfs_term .selected_terms .remove', function() {
+                    var div = $(this).parent();
+                    var parent = div.closest('.field');
+                    var term_id = div.attr('rel');
+                    parent.find('.available_terms div[rel='+post_id+']').removeClass('used');
+                    div.remove();
+                    update_term_values(parent);
+                });
+
+                // filter posts
+                $(document).on('keyup', '.cfs_term .cfs_filter_input', function() {
+                    var input = $(this).val();
+                    var parent = $(this).closest('.field');
+                    var regex = new RegExp(input, 'i');
+                    parent.find('.available_terms div:not(.used)').each(function() {
+                        if (-1 < $(this).html().search(regex)) {
+                            $(this).removeClass('hidden');
+                        }
+                        else {
+                            $(this).addClass('hidden');
+                        }
+                    });
+                });
+            });
+
+            $.fn.init_term = function() {
+                this.each(function() {
+                    var $this = $(this);
+                    $this.addClass('ready');
+
+                    // sortable
+                    $this.find('.selected_terms').sortable({
+                        axis: 'y',
+                        update: function(event, ui) {
+                            var parent = $(this).closest('.field');
+                            update_term_values(parent);
+                        }
+                    });
+                });
+            }
+        })(jQuery);
+        </script>
+    <?php
+    }
+
+
+    function prepare_value( $value, $field = null ) {
+        return $value;
+    }
+
+
+    function format_value_for_input( $value, $field = null ) {
+        return empty( $value ) ? '' : implode( ',', $value );
+    }
+
+
+    function pre_save( $value, $field = null ) {
+        if ( ! empty( $value ) ) {
+
+            // Inside a loop, the value is $value[0]
+            $value = (array) $value;
+
+            // The raw input saves a comma-separated string
+            if ( false !== strpos( $value[0], ',' ) ) {
+                return explode( ',', $value[0] );
+            }
+
+            return $value;
+        }
+
+        return array();
+    }
+}

--- a/includes/fields/term.php
+++ b/includes/fields/term.php
@@ -34,9 +34,18 @@ class cfs_term extends cfs_field
         );
 
         $args = apply_filters( 'cfs_field_term_query_args', $args, array( 'field' => $field ) );
-        $query = new WP_Term_Query( $args );
 
-        foreach ( $query->terms as $term_id ) {
+        // Use older `get_terms` function signature for older versions of WP
+        if ( version_compare( get_bloginfo('version'), '4.5', '<' ) ) {
+            $taxonomy = $args['taxonomy'];
+            unset( $args['taxonomy'] );
+
+            $query = get_terms( $taxonomy, $args );
+        } else {
+            $query = get_terms( $args );
+        }
+
+        foreach ( $query as $term_id ) {
             $term = get_term( $term_id );
             $available_posts[] = (object) array(
                 'term_id'  => $term->term_id,

--- a/includes/init.php
+++ b/includes/init.php
@@ -104,6 +104,7 @@ class cfs_init
             'true_false'    => CFS_DIR . '/includes/fields/true_false.php',
             'select'        => CFS_DIR . '/includes/fields/select.php',
             'relationship'  => CFS_DIR . '/includes/fields/relationship.php',
+            'term'          => CFS_DIR . '/includes/fields/term.php',
             'user'          => CFS_DIR . '/includes/fields/user.php',
             'file'          => CFS_DIR . '/includes/fields/file.php',
             'loop'          => CFS_DIR . '/includes/fields/loop.php',


### PR DESCRIPTION
This is a 'fork' of the Relationship and User fields, modified to find taxonomy terms. It allows the administrator to choose one or more taxonomies from which a user can select terms.

Creating the field:

![edit_field_group_ _ecommercefuel_directories_ _wordpress](https://cloud.githubusercontent.com/assets/1231306/18788701/e8a30526-8175-11e6-880e-56aababc894b.jpg)

Using the field:

![edit_page_ _ecommercefuel_directories_ _wordpress](https://cloud.githubusercontent.com/assets/1231306/18788719/f3d1f92a-8175-11e6-9897-5d4377f9c315.jpg)

The code is essentially a copy/paste/find/replace job on the Relationship and User fields, and has been very stable in my testing.

The only area of potential concern is a backwards compatibility conditional I put in place for `get_terms`, as the function signature changed in WordPress 4.5. Here's how it looks:

```php
// Use older `get_terms` function signature for older versions of WP
if ( version_compare( get_bloginfo('version'), '4.5', '<' ) ) {
    $taxonomy = $args['taxonomy'];
    unset( $args['taxonomy'] );

    $query = get_terms( $taxonomy, $args );
} else {
    $query = get_terms( $args );
}
```

This should handle it smoothly, but I'd love another pair of eyes/testing to be certain :)