### PR TITLE
Switch the "Notes" field to a textarea, instead of a text input

### DIFF
--- a/templates/field_html.php
+++ b/templates/field_html.php
@@ -71,7 +71,7 @@
                         </label>
                     </td>
                     <td>
-                        <input type="text" name="cfs[fields][<?php echo $field->weight; ?>][notes]" value="<?php echo esc_attr( $field->notes ); ?>" />
+                        <textarea name="cfs[fields][<?php echo $field->weight; ?>][notes]"><?php echo esc_textarea( $field->notes ); ?></textarea>
                     </td>
                 </tr>
                 <tr class="field_actions">


### PR DESCRIPTION
A while ago, in #368, I had proposed switching field notes to a textarea, instead of a text input.

However that issue also came with a lot of baggage, because I was also trying to change how the output of said field was formatted… dealing with auto-paragraphs or line breaks, HTML or not, etc. Kind of a lot to tackle at once.

**This PR, instead, is an incremental step forward. It just changes the notes field to a textarea. There are no changes to how the text is processed.**

I'd still like to look at adjusting the formatting in the future, but I think there are still too many questions about the best way to approach that. Switching to a textarea, even without changing how the text is processed, yields immediate user experience benefits without additional complications.

Let me know what you think!