### PR TITLE
Pass the notes value along with create_field

### DIFF
--- a/includes/form.php
+++ b/includes/form.php
@@ -409,6 +409,7 @@ CFS['loop_buffer'] = [];
                     'input_class'   => $field->type,
                     'options'       => $field->options,
                     'value'         => $field->value,
+                    'notes'         => $field->notes,
                 ) );
     ?>
 


### PR DESCRIPTION
Can you tell I'm working on something with notes? 😄 

This PR passes along the value of `$field->notes` with the `create_field` attributes, so it can be used inside the field's `html()` method.

Only question, @mgibbs189: should I also include `notes` in the `$defaults` array inside the `create_field` method definition? It should always come through with the args so I don't think a fallback is strictly necessary, but I may be  missing something obvious!