### PR TITLE
Fix plugin url detection

### DIFF
--- a/cfs.php
+++ b/cfs.php
@@ -24,7 +24,7 @@ class Custom_Field_Suite
         // setup variables
         define( 'CFS_VERSION', '2.5.12' );
         define( 'CFS_DIR', dirname( __FILE__ ) );
-        define( 'CFS_URL', plugins_url( 'custom-field-suite' ) );
+        define( 'CFS_URL', plugins_url( '', __FILE__ ) );
 
         // get the gears turning
         include( CFS_DIR . '/includes/init.php' );


### PR DESCRIPTION
In order to support installing CFS as a Must Use plugin in the `mu-plugins` directory, the CFS URL needs to be fixed.

Before the change, CFS_URL was always located under `/plugins/`. Now, if the plugin is a Must Use plugin, it is correctly located under `/mu-plugins/`. This fixes a number of 404 errors for CFS assets on the admin page.