### PR TITLE
Add action to append options to all fields

### DIFF
--- a/templates/field_html.php
+++ b/templates/field_html.php
@@ -61,7 +61,7 @@
 
                 <?php CFS()->fields[ $field->type ]->options_html( $field->weight, $field ); ?>
 
-                <?php do_action( 'cfs_after_field_html', $field->weight, $field ); ?>
+                <?php do_action( 'cfs_after_field_html', CFS()->fields[ $field->type ], $field->weight, $field ); ?>
 
                 <tr class="field_notes">
                     <td class="label">

--- a/templates/field_html.php
+++ b/templates/field_html.php
@@ -61,7 +61,7 @@
 
                 <?php CFS()->fields[ $field->type ]->options_html( $field->weight, $field ); ?>
 
-                <?php do_action( 'cfs_after_field_html', $field ); ?>
+                <?php do_action( 'cfs_after_field_html', $field->weight, $field ); ?>
 
                 <tr class="field_notes">
                     <td class="label">

--- a/templates/field_html.php
+++ b/templates/field_html.php
@@ -61,6 +61,8 @@
 
                 <?php CFS()->fields[ $field->type ]->options_html( $field->weight, $field ); ?>
 
+                <?php do_action( 'cfs_after_field_html', $field ); ?>
+
                 <tr class="field_notes">
                     <td class="label">
                         <label>


### PR DESCRIPTION
I am wanting to add some global options to all of my fields, but to my dismay there were no actions inside of the field_html renderer that would allow you to do this. Currently the only way to have custom field_html is to extend a field in a subclass, but that doesn't work when you want to add global options to all fields.