### PR TITLE
get_fields() allow sorting by backend order

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -56,7 +56,7 @@ class cfs_api
     public function get_fields( $post_id, $options ) {
         global $post, $wpdb;
 
-        $defaults = array( 'format' => 'api' ); // "api", "input", or "raw"
+        $defaults = array( 'format' => 'api', 'sorting' => false ); // format: "api", "input", or "raw", sorting: true|false
         $options = array_merge( $defaults, $options );
         $post_id = empty( $post_id ) ? $post->ID : (int) $post_id;
 
@@ -88,7 +88,15 @@ class cfs_api
                 FROM {$wpdb->prefix}cfs_values v
                 INNER JOIN {$wpdb->postmeta} m ON m.meta_id = v.meta_id
                 WHERE v.field_id IN ($field_ids) AND v.post_id IN ($post_id)
-                ORDER BY v.depth, FIELD(v.field_id, $field_ids), v.weight, v.sub_weight";
+                ";
+
+                if ($options['sorting']) {
+                    // Sort by order of CSF-Items on the page in the Wordpress Backend
+                    $sql .= "ORDER BY v.depth                               , v.weight, v.sub_weight";
+                } else {
+                    // Default sorting
+                    $sql .= "ORDER BY v.depth, FIELD(v.field_id, $field_ids), v.weight, v.sub_weight";
+                }
 
                 $results = $wpdb->get_results( $sql );
                 $num_rows = $wpdb->num_rows;


### PR DESCRIPTION
My use case: 
- I have defined two field groups
- On the first page, the fieldgroups are in default order:
[fieldgroup1]
[fieldgroup2]

- On the second page the fieldgroups are in reversed order:
[fieldgroup2]
[fieldgroup1]

My problem:
The return value of $fields = CFS()->get(); is the same, for both pages. 
E.g. page1: 
- fieldgroup1
- fieldgroup2

E.g. page2: 
- fieldgroup1  --> Sort order in Backend is NOT recognized
- fieldgroup2  --> Sort order in Backend is NOT recognized

My solution:
I have changed the SQL-Query in get_fields() and added an option to switch
$fields1 = CFS()->get(false, false, array('sorting' => true));

Now I get: 

E.g. page1: 
- fieldgroup1
- fieldgroup2

E.g. page2: 
- fieldgroup2  --> Sort order in Backend is recognized
- fieldgroup1  --> Sort order in Backend is recognized

Cheers
uwe