### PR TITLE
lower the priority of duplicate_post action hook.

### DIFF
--- a/includes/third_party.php
+++ b/includes/third_party.php
@@ -12,8 +12,8 @@ class cfs_third_party
         add_action( 'icl_make_duplicate', array( $this, 'wpml_handler' ), 10, 4 );
 
         // Duplicate Post - http://wordpress.org/plugins/duplicate-post/
-        add_action( 'dp_duplicate_post', array( $this, 'duplicate_post' ), 20, 2 );
-        add_action( 'dp_duplicate_page', array( $this, 'duplicate_post' ), 20, 2 );
+        add_action( 'dp_duplicate_post', array( $this, 'duplicate_post' ), 100, 2 );
+        add_action( 'dp_duplicate_page', array( $this, 'duplicate_post' ), 100, 2 );
     }
 
 


### PR DESCRIPTION
when execute duplicate post, could not duplicate fields to a new post.

I found out that because the timing was too early and it was executed before being copied.
For example, taxonomy is not copied, so it does not apply to duplication conditions for cfs.

Please see below.
https://github.com/enricobattocchi/duplicate-post/blob/master/duplicate-post-admin.php#L66-L84

I lower the priority number of duplicate_post, it was improved.