### PR TITLE
Allow users to filter field IDs before deleting associated meta

### DIFF
--- a/includes/field_group.php
+++ b/includes/field_group.php
@@ -253,6 +253,9 @@ class cfs_field_group
         // Remove values for deleted fields
         $deleted_field_ids = array_diff( array_keys( $prev_fields ), $current_field_ids );
 
+        // Filter deleted field IDs before deleting meta
+        $deleted_field_ids = apply_filters( 'cfs_deleted_field_ids', $deleted_field_ids );
+
         if ( 0 < count( $deleted_field_ids ) ) {
             $deleted_field_ids = implode( ',', $deleted_field_ids );
             $wpdb->query("


### PR DESCRIPTION
This PR introduces a filter that allows users to filter the array of deleted field IDs before meta is deleted.

This allows you to prevent CFS from deleting post meta when a field is deleted with a snippet like this:

```php
add_filter( 'cfs_deleted_field_ids', function ($deleted_field_ids) {
    return [];
} );
```

Obviously you can also be more selective by only filtering out specific IDs, if you have certain fields where you want to be sure that meta is preserved.