### PR TITLE
Clean `$buffer` from non utf-8 characters

### DIFF
--- a/includes/fields/loop.php
+++ b/includes/fields/loop.php
@@ -154,7 +154,7 @@ class cfs_loop extends cfs_field
             </div>
         </div>
     <?php
-        $buffer = ob_get_clean();
+        $buffer = mb_convert_encoding( ob_get_clean(), 'UTF-8', 'UTF-8' );
     ?>
 
         <script>


### PR DESCRIPTION
Non utf-8 characters will break `json_encode()` on line 161. This will prevent it.