### PR TITLE
Restore Import/Export page, accidentally removed in the latest release

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -15,6 +15,7 @@ class cfs_init
         }
 
         add_action( 'admin_head',                       [ $this, 'admin_head' ] );
+        add_action( 'admin_menu',                       [ $this, 'admin_menu' ] );
         add_action( 'admin_footer',                     [ $this, 'show_credits' ] );
         add_action( 'save_post',                        [ $this, 'save_post' ] );
         add_action( 'delete_post',                      [ $this, 'delete_post' ] );
@@ -143,6 +144,14 @@ class cfs_init
         }
     }
 
+    /**
+    * admin_menu
+    */
+    function admin_menu() {
+        if ( false === apply_filters( 'cfs_disable_admin', false ) ) {
+            add_submenu_page( 'tools.php', __( 'CFS Tools', 'cfs' ), __( 'CFS Tools', 'cfs' ), 'manage_options', 'cfs-tools', [ $this, 'page_tools' ] );
+        }
+    }
 
     /**
      * add_meta_boxes


### PR DESCRIPTION
Hi @mgibbs189 
In [one of your latest commits,](https://github.com/mgibbs189/custom-field-suite/commit/465bc3850e6a24cb09902411b0fde64335fb0e2e) in which you've moved the CFS menu under Wordpress Settings, you've accidentally removed the "Tools" page from the plugin.

In this PR I'm re-adding it under the Wordpress' Tools menu.

Let me know what you think!

<img width="605" alt="Screenshot 2020-09-06 at 21 29 44" src="https://user-images.githubusercontent.com/5167659/92333734-1a8eb500-f088-11ea-8872-3420d5090e58.png">
