### PR TITLE
Added clearfix to keep loop header from collapsing

### DIFF
--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -356,6 +356,12 @@
     cursor: move;
 }
 
+.cfs_loop .cfs_loop_head:after {
+    content: "";
+    display: block;
+    clear: both;
+}
+
 .cfs_loop .notes {
     font-size: 11px;
     font-style: italic;


### PR DESCRIPTION
"Clearfix" added to loop header to force it to wrap around floated child element.

Before:
![before](https://user-images.githubusercontent.com/332098/97222463-bd34fb80-17ce-11eb-99ca-324a7abc35e4.png)

After
![after](https://user-images.githubusercontent.com/332098/97222376-9b3b7900-17ce-11eb-90e7-78207bd4236d.png)
