### PR TITLE
Enable code and link plugin in TinyMCE

### DIFF
--- a/includes/fields/wysiwyg.php
+++ b/includes/fields/wysiwyg.php
@@ -138,6 +138,8 @@ class cfs_wysiwyg extends cfs_field
                     // create wysiwyg
                     wpautop = tinyMCE.settings.wpautop;
                     resize = tinyMCE.settings.resize;
+                    
+                    tinyMCE.settings.plugins = 'code,link';
 
                     tinyMCE.settings.wpautop = false;
                     tinyMCE.settings.resize = 'vertical';


### PR DESCRIPTION
This pull request is based on a fix we at @monade did in production to restore the tinyMCE "link" and "code" buttons in the toolbar. It just enables the plugin as per tinyMCE documentation.