### PR TITLE
Compatability with ShortcodesUI rendering

### DIFF
--- a/includes/fields/wysiwyg.php
+++ b/includes/fields/wysiwyg.php
@@ -139,7 +139,13 @@ class cfs_wysiwyg extends cfs_field
                     wpautop = tinyMCE.settings.wpautop;
                     resize = tinyMCE.settings.resize;
                     
-                    tinyMCE.settings.plugins = 'code,link';
+                    if (tinyMCE.settings.plugins){
+                        if ( tinyMCE.settings.plugins.indexOf('code,link') === -1 ){
+                            tinyMCE.settings.plugins = tinyMCE.settings.plugins + ',code,link';
+                        }
+                    } else {
+                        tinyMCE.settings.plugins = 'code,link';
+                    }
 
                     tinyMCE.settings.wpautop = false;
                     tinyMCE.settings.resize = 'vertical';


### PR DESCRIPTION
https://github.com/mgibbs189/custom-field-suite/pull/476#issue-1279802505

Hard redefining "tinyMCE.settings.plugins" cause shortcodes rendering problem with "Shortcake (Shortcode UI)" plugin. It's better to add plugins to existing list instead.